### PR TITLE
Schedule notifications for all walks in the next 10 days instead of just one

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,7 +25,7 @@ void backgroundFetchHeadlessTask(HeadlessTask task) async {
     print("[BackgroundFetch] Headless task: $taskId");
     await dotenv.load(fileName: '.env');
     await updateWalks();
-    await scheduleNextNearestWalkNotification();
+    await scheduleNextNearestWalkNotifications();
     await PrefsProvider.prefs.setString(
         "last_background_fetch", DateTime.now().toUtc().toIso8601String());
   } catch (err) {

--- a/lib/views/settings/debug.dart
+++ b/lib/views/settings/debug.dart
@@ -78,9 +78,9 @@ class _PendingNotificationsTile extends StatelessWidget {
             if (requests.isNotEmpty) {
               return ListTile(
                 isThreeLine: true,
-                title: const Text("Prochaine notification planifiée"),
+                title: const Text("Prochaines notifications planifiées"),
                 subtitle: Text(
-                  requests[0].title! + '\n' + requests[0].body!,
+                  generatePendingNotificationsSubtitle(requests),
                   style: const TextStyle(fontSize: 12.0),
                 ),
               );
@@ -89,6 +89,18 @@ class _PendingNotificationsTile extends StatelessWidget {
           return const SizedBox.shrink();
         });
   }
+}
+
+String generatePendingNotificationsSubtitle(List<PendingNotificationRequest> requests) {
+  String result = "";
+  for (int i = 0; i < requests.length; i++) {
+    PendingNotificationRequest request = requests[i];
+    result = result + request.title! + '\n' + request.body!;
+    if (i != requests.length - 1) {
+      result = result + "\n\n";
+    }
+  }
+  return result;
 }
 
 class _LastBackgroundFetch extends StatelessWidget {

--- a/lib/views/settings/settings.dart
+++ b/lib/views/settings/settings.dart
@@ -61,7 +61,7 @@ class _SettingsState extends State<Settings> {
       _home = label;
     });
     if (_showNotification == true) {
-      scheduleNextNearestWalkNotification();
+      scheduleNextNearestWalkNotifications();
     }
   }
 
@@ -71,7 +71,7 @@ class _SettingsState extends State<Settings> {
     setState(() {
       _home = null;
     });
-    NotificationManager.instance.cancelNextNearestWalkNotification();
+    NotificationManager.instance.cancelNextNearestWalkNotifications();
   }
 
   Future<void> _setUseLocation(bool newValue) async {
@@ -97,13 +97,13 @@ class _SettingsState extends State<Settings> {
       bool? notificationsAllowed =
           await NotificationManager.instance.requestNotificationPermissions();
       if (notificationsAllowed == true) {
-        scheduleNextNearestWalkNotification();
+        scheduleNextNearestWalkNotifications();
       } else {
         _setShowNotification(false);
         return;
       }
     } else {
-      NotificationManager.instance.cancelNextNearestWalkNotification();
+      NotificationManager.instance.cancelNextNearestWalkNotifications();
     }
     setState(() {
       _showNotification = newValue;

--- a/lib/walks_home_screen.dart
+++ b/lib/walks_home_screen.dart
@@ -83,7 +83,7 @@ class _WalksHomeScreenState extends State<WalksHomeScreen>
             startOnBoot: true), (String taskId) async {
       print("[BackgroundFetch] taskId: $taskId");
       try {
-        await scheduleNextNearestWalkNotification();
+        await scheduleNextNearestWalkNotifications();
         await PrefsProvider.prefs.setString(
             "last_background_fetch", DateTime.now().toUtc().toIso8601String());
       } catch (err) {


### PR DESCRIPTION
Most of the time, each walk is separated by a full week. However, sometimes, like for the moment, they are separated by just a day. It means that notifications are not always scheduled in time, especially on iOS where the background task might not be executed for a week.

This PR attempts to fix that, by scheduling notifications for all walks in the next 10 days, instead of scheduling only the next one.