### PR TITLE
Upgraded flutter_native_splash and changed how initialization is done…

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,17 +51,14 @@ Future<void> _addTrustedCert(String certPath) async {
 }
 
 void main() async {
-  FlutterNativeSplash.removeAfter(initialization);
-  runApp(const MyApp());
-}
-
-void initialization(BuildContext context) async {
+  WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+  FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await dotenv.load();
-  WidgetsFlutterBinding.ensureInitialized();
   //TODO: improve how we initialize these singletons (get_it package?)
   await NotificationManager.instance.plugin;
   await DBProvider.db.database;
   await _addTrustedCert(Assets.letsEncryptCert);
+  runApp(const MyApp());
   BackgroundFetch.registerHeadlessTask(backgroundFetchHeadlessTask);
 }
 

--- a/lib/walks_home_screen.dart
+++ b/lib/walks_home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:background_fetch/background_fetch.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:points_verts/services/notification.dart';
 import 'package:points_verts/services/prefs.dart';
 import 'package:points_verts/views/loading.dart';
@@ -34,6 +35,7 @@ class _WalksHomeScreenState extends State<WalksHomeScreen>
       _initPlatformState();
     }).catchError((err) {
       print("error init state");
+      FlutterNativeSplash.remove();
     });
     PrefsProvider.prefs.remove("last_selected_date");
     WidgetsBinding.instance!.addObserver(this);
@@ -72,6 +74,7 @@ class _WalksHomeScreenState extends State<WalksHomeScreen>
   }
 
   Future<void> _initPlatformState() async {
+    FlutterNativeSplash.remove();
     BackgroundFetch.configure(
         BackgroundFetchConfig(
             minimumFetchInterval: 60 * 6,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -213,7 +213,7 @@ packages:
       name: flutter_native_splash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:


### PR DESCRIPTION
… to prevent potential race condition

I noticed that when the database is upgraded (like when coming from master to gpx branch), and if the last walk update was more than an hour ago, there is a race condition where the background task and the app try together to upgrade/update the list of walks, which make the walk list a bit corrupt.

I upgraded the flutter_native_splash to fix that, and reused the old code that ensure that the database is properly opened (and thus upgraded) before doing anything.