### PR TITLE
Disable Android backup

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         </intent>
     </queries>
     <application
+        android:allowBackup="false"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:label="ADEPS\nPoints Verts">


### PR DESCRIPTION
Disables the android backup, possible fix for app data not being deleted when app is uninstalled