### PR TITLE
Tweak address search with Google to be more like Mapbox one

### DIFF
--- a/lib/services/map/googlemaps.dart
+++ b/lib/services/map/googlemaps.dart
@@ -70,7 +70,12 @@ class GoogleMaps implements MapInterface {
   Future<List<AddressSuggestion>> retrieveSuggestions(
       String country, String search) async {
     if (search.isNotEmpty) {
-      var body = {"query": search, "key": _apiKey};
+      var body = {
+        "query": search,
+        "key": _apiKey,
+        "region": country,
+        "language": "fr_BE"
+      };
       Uri url = Uri.https(
           "maps.googleapis.com", "/maps/api/place/textsearch/json", body);
       http.Response response = await http.get(url);


### PR DESCRIPTION
Country was never used on the google implementation for address search, meaning that for example, for my address, addresses in France are appearing before my address in Belgium, even if "Belgium" was selected.