### PR TITLE
Load initial walk dataset from local JSON

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Touch placeholder files
         run: |
           touch .env
+          touch assets/walk_data.json
           cp assets/dummy.png assets/light/splash.png
           cp assets/dummy.png assets/dark/splash.png
           cp assets/dummy_icon.png assets/launcher_icons/icon_812x812.png

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ key.jks
 /app_icons/
 
 # assets
+/assets/walk_data.json
 /assets/light/*.png
 /assets/dark/*.png
 /assets/google_static_markers/

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ flutter pub run flutter_launcher_icons:main
 flutter build appbundle
 ```
 
+# Initial walk dataset
+
+If you want the app to load an initial dataset without connecting to the internet, place a JSON
+file called `walk_data.json` in `assets` folder. This JSON must follows the schema of ODWB.
+
 # App assets and icons
 
 Due to copyright issues => below assets, files and folders are not included:

--- a/lib/services/adeps.dart
+++ b/lib/services/adeps.dart
@@ -16,27 +16,14 @@ const int pageSize = 500;
 
 Future<List<Walk>> fetchAllWalks({DateTime? fromDateLocal}) async {
   try {
-    return readAllWalksFromJson();
+    final String response =
+        await rootBundle.loadString('assets/walk_data.json');
+    Map<String, dynamic> data = await json.decode(response);
+    return _convertWalks(data);
   } catch (e) {
     log("Cannot retrieve walks from JSON file: $e");
     return [];
   }
-}
-
-Future<List<Walk>> readAllWalksFromJson() async {
-  log("Reading all future walks from JSON", name: tag);
-  List<Walk> walks = [];
-  final String response = await rootBundle.loadString('assets/walk_data.json');
-  final data = await json.decode(response);
-  final DateTime now = DateTime.now();
-  final DateTime today = DateTime(now.year, now.month, now.day);
-  for (Map<String, dynamic> walkJson in data) {
-    Walk walk = Walk.fromJson(walkJson);
-    if (!walk.date.isBefore(today)) {
-      walks.add(walk);
-    }
-  }
-  return walks;
 }
 
 Future<List<Walk>> refreshAllWalks(String lastUpdateIso8601Utc,
@@ -82,12 +69,17 @@ Future<List<WebsiteWalk>> retrieveWalksFromWebSite(DateTime date) async {
 }
 
 List<Walk> _convertWalks(Map<String, dynamic> data) {
-  List<Walk> newList = [];
-  List<dynamic> list = data['records'];
-  for (Map<String, dynamic> walkJson in list) {
-    newList.add(Walk.fromJson(walkJson));
+  final DateTime now = DateTime.now();
+  final DateTime today = DateTime(now.year, now.month, now.day);
+
+  List<Walk> walks = [];
+  for (Map<String, dynamic> walkJson in data['records']) {
+    Walk walk = Walk.fromJson(walkJson);
+    if (!walk.date.isBefore(today)) {
+      walks.add(walk);
+    }
   }
-  return newList;
+  return walks;
 }
 
 String? _convertStatus(String webSiteStatus) {

--- a/lib/services/adeps.dart
+++ b/lib/services/adeps.dart
@@ -31,13 +31,9 @@ Future<List<Walk>> readAllWalksFromJson() async {
   final DateTime now = DateTime.now();
   final DateTime today = DateTime(now.year, now.month, now.day);
   for (Map<String, dynamic> walkJson in data) {
-    try {
-      Walk walk = Walk.fromJson(walkJson);
-      if (!walk.date.isBefore(today)) {
-        walks.add(walk);
-      }
-    } catch (e) {
-      log("Cannot parse walk: $e");
+    Walk walk = Walk.fromJson(walkJson);
+    if (!walk.date.isBefore(today)) {
+      walks.add(walk);
     }
   }
   return walks;

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -164,4 +164,10 @@ class DBProvider {
       return null;
     }
   }
+
+  Future<bool> isWalkTableEmpty() async {
+    final Database db = await database;
+    List results = await db.query('walks');
+    return results.isEmpty;
+  }
 }

--- a/lib/views/walks/walk_utils.dart
+++ b/lib/views/walks/walk_utils.dart
@@ -142,6 +142,10 @@ Future<void> updateWalks() async {
     } catch (err) {
       print("Cannot refresh walks list: $err");
     }
+
+    if (await DBProvider.db.isWalkTableEmpty()) {
+      throw Exception('walk table is empty');
+    }
   } else {
     log("Not refreshing walks list since it has been done less than an hour ago",
         name: tag);

--- a/lib/views/walks/walk_utils.dart
+++ b/lib/views/walks/walk_utils.dart
@@ -157,8 +157,8 @@ DateTime getLastUpdateTimestamp(List<Walk> walks) {
   // ago, so that updateWalks will retrieve them all
   DateTime lastUpdate = DateTime.now().subtract(const Duration(days: 365));
   for (Walk walk in walks) {
-    if (walk.date.isAfter(lastUpdate)) {
-      lastUpdate = walk.date;
+    if (walk.lastUpdated.isAfter(lastUpdate)) {
+      lastUpdate = walk.lastUpdated;
     }
   }
   return lastUpdate;

--- a/lib/views/walks/walk_utils.dart
+++ b/lib/views/walks/walk_utils.dart
@@ -121,31 +121,43 @@ Future<void> updateWalks() async {
   String nowIso8601Utc = nowDateUtc.toIso8601String();
   if (lastUpdateIso8601Utc == null) {
     List<Walk> newWalks = await fetchAllWalks(fromDateLocal: nowDateLocal);
+    // JSON might be out of date
+    lastUpdateIso8601Utc = getLastUpdateTimestamp(newWalks).toIso8601String();
     if (newWalks.isNotEmpty) {
       await DBProvider.db.insertWalks(newWalks, empty: true);
-      PrefsProvider.prefs.setString(Prefs.lastWalkUpdate, nowIso8601Utc);
-      await _fixNextWalks();
-    }
-  } else {
-    if (nowDateUtc.difference(DateTime.parse(lastUpdateIso8601Utc)) >
-        const Duration(hours: 1)) {
-      try {
-        List<Walk> updatedWalks = await refreshAllWalks(lastUpdateIso8601Utc,
-            fromDateLocal: nowDateLocal);
-        if (updatedWalks.isNotEmpty) {
-          await DBProvider.db.insertWalks(updatedWalks);
-        }
-        PrefsProvider.prefs.setString(Prefs.lastWalkUpdate, nowIso8601Utc);
-        await _fixNextWalks();
-        await DBProvider.db.deleteOldWalks();
-      } catch (err) {
-        print("Cannot refresh walks list: $err");
-      }
-    } else {
-      log("Not refreshing walks list since it has been done less than an hour ago",
-          name: tag);
+      PrefsProvider.prefs.setString(Prefs.lastWalkUpdate, lastUpdateIso8601Utc);
     }
   }
+  if (nowDateUtc.difference(DateTime.parse(lastUpdateIso8601Utc)) >
+      const Duration(hours: 1)) {
+    try {
+      List<Walk> updatedWalks = await refreshAllWalks(lastUpdateIso8601Utc,
+          fromDateLocal: nowDateLocal);
+      if (updatedWalks.isNotEmpty) {
+        await DBProvider.db.insertWalks(updatedWalks);
+      }
+      PrefsProvider.prefs.setString(Prefs.lastWalkUpdate, nowIso8601Utc);
+      await _fixNextWalks();
+      await DBProvider.db.deleteOldWalks();
+    } catch (err) {
+      print("Cannot refresh walks list: $err");
+    }
+  } else {
+    log("Not refreshing walks list since it has been done less than an hour ago",
+        name: tag);
+  }
+}
+
+DateTime getLastUpdateTimestamp(List<Walk> walks) {
+  // in case we have no walks (JSON too old), then set by default to a year
+  // ago, so that updateWalks will retrieve them all
+  DateTime lastUpdate = DateTime.now().subtract(const Duration(days: 365));
+  for (Walk walk in walks) {
+    if (walk.date.isAfter(lastUpdate)) {
+      lastUpdate = walk.date;
+    }
+  }
+  return lastUpdate;
 }
 
 Future<List<DateTime>> retrieveNearestDates() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,7 @@ flutter:
   #  - images/a_dot_ham.jpeg
   assets:
     - .env
+    - assets/walk_data.json
     - assets/light/
     - assets/dark/
     - assets/raw/


### PR DESCRIPTION
Here is the new algorithm to retrieve/update walks:

- if walks were never updated (e.g. new install), then we have no last update timestamp:
  - we retrieve all walks from JSON file, with date >= today
  - we set the last update timestamp to the last updated timestamp found in walks
  - we call the API to retrieve updated walks since this last update timestamp
- if walks were updated before (we have a list update timestamp), then we just call the API to retrieve updated walks since this last update timestamp

If for some reasons JSON contains no walks, then we ask the API to retrieve all walks in the future that have been updated at least a year ago. It should like this behave like our previous full fetch strategy.