### PR TITLE
Fix background fetch no longer working because of uninitialized Firebase

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         </intent>
     </queries>
     <application
+        tools:replace="android:label"
         android:allowBackup="false"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
          minSdkVersion       = 21
          compileSdkVersion   = 33
          targetSdkVersion    = 33
-         appCompatVersion    = "1.0.2"
+         appCompatVersion    = "1.4.2"
     }
     repositories {
         google()
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: background_fetch
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.4"
   boolean_selector:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
   flutter: ^3.3.0
 
 dependencies:
-  background_fetch: ^1.0.0
+  background_fetch: ^1.1.4
   cached_network_image: ^3.0.0-nullsafety
   collection: ^1.15.0-nullsafety.4
   csv: ^5.0.0


### PR DESCRIPTION
Background fetches were not working anymore for me on Android.

After looking at the log, it seems to crash early because we try to set a custom key in Crashlytics, but before we initialize Firebase. Error is caught by the try/catch with only a print, so the `runZonedGuarded` around the whole function is never triggered, and the error not sent to Crashlytics (would not work for the same reason).

Made some changes to simplify everything:
- Updated `background_fetch` library to the latest version (and added an annotation for Android 13 compat)
- Removed `runZonedGuarded`
- Initialized Firebase before we call any Crashlytics methods
- Moved all that Firebase stuff in the catch clause, as we only need that in case of errors
- Removed calls to `FirebaseCrashlytics.instance.setCustomKey` as
    1) Firebase put directly the correct value when initialized
    2) instance is deleted once the job is finished, so no need to set it to foreground