### PR TITLE
Tweak padding on walk list

### DIFF
--- a/lib/views/walks/walk_tile.dart
+++ b/lib/views/walks/walk_tile.dart
@@ -57,7 +57,7 @@ class WalkTile extends StatelessWidget {
               ? const SizedBox.shrink()
               : Positioned(
                   right: 20,
-                  top: 20,
+                  top: 15,
                   child: GeoButton(walk),
                 ),
         ],

--- a/lib/views/walks/walk_tile.dart
+++ b/lib/views/walks/walk_tile.dart
@@ -25,42 +25,31 @@ class WalkTile extends StatelessWidget {
       header: true,
       label: walk.city,
       explicitChildNodes: true,
-      child: Stack(
-        children: [
-          Card.outlined(
-            elevation: 2.0,
-            semanticContainer: false,
-            margin: tileType == TileType.map
-                ? const EdgeInsets.only()
-                : const EdgeInsets.symmetric(vertical: 5.0, horizontal: 10.0),
-            shape: tileType == TileType.map
-                ? const RoundedRectangleBorder(
-                    borderRadius:
-                        BorderRadius.vertical(top: Radius.circular(20)))
-                : null,
-            child: MergeSemantics(
-              child: Semantics(
-                button: true,
-                hint: "Ouvrir la page de détail de l'évènement",
-                child: InkWell(
-                  onTap: () => Navigator.push(context, _pageRoute()),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: getChildren(context),
-                  ),
-                ),
+      child: Card.outlined(
+        elevation: 2.0,
+        semanticContainer: false,
+        margin: tileType == TileType.map
+            ? const EdgeInsets.only()
+            : const EdgeInsets.symmetric(vertical: 5.0, horizontal: 10.0),
+        shape: tileType == TileType.map
+            ? const RoundedRectangleBorder(
+                borderRadius:
+                    BorderRadius.vertical(top: Radius.circular(20)))
+            : null,
+        child: MergeSemantics(
+          child: Semantics(
+            button: true,
+            hint: "Ouvrir la page de détail de l'évènement",
+            child: InkWell(
+              onTap: () => Navigator.push(context, _pageRoute()),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: getChildren(context),
               ),
             ),
           ),
-          tileType == TileType.directory || walk.isCancelled
-              ? const SizedBox.shrink()
-              : Positioned(
-                  right: 20,
-                  top: 15,
-                  child: GeoButton(walk),
-                ),
-        ],
+        ),
       ),
     );
   }
@@ -81,7 +70,7 @@ class WalkTile extends StatelessWidget {
                           color: CompanyColors.contextualRed(context)),
                     ),
                   )
-                : const SizedBox.shrink(),
+                : GeoButton(walk),
       ),
     ];
 

--- a/lib/views/walks/walk_tile.dart
+++ b/lib/views/walks/walk_tile.dart
@@ -38,19 +38,16 @@ class WalkTile extends StatelessWidget {
                     borderRadius:
                         BorderRadius.vertical(top: Radius.circular(20)))
                 : null,
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(0, 8.0, 18.0, 8.0),
-              child: MergeSemantics(
-                child: Semantics(
-                  button: true,
-                  hint: "Ouvrir la page de détail de l'évènement",
-                  child: InkWell(
-                    onTap: () => Navigator.push(context, _pageRoute()),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: getChildren(context),
-                    ),
+            child: MergeSemantics(
+              child: Semantics(
+                button: true,
+                hint: "Ouvrir la page de détail de l'évènement",
+                child: InkWell(
+                  onTap: () => Navigator.push(context, _pageRoute()),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: getChildren(context),
                   ),
                 ),
               ),


### PR DESCRIPTION
Tweak a bit the walk list layout:

- Reduced inner padding so that the tile takes less space
- This also allow the divider to take the whole width instead of a blank space on the right
- This also fixes the overlay when taping on a tile that was not taking the whole tile before.
![Screenshot_20240529_191811](https://github.com/etnic-elab/points_verts/assets/6358113/4df08fac-9729-4483-9886-77ebc788b8b9)
