### PR TITLE
Simplify company theme and support Material You

### DIFF
--- a/lib/company_data.dart
+++ b/lib/company_data.dart
@@ -42,8 +42,8 @@ class CompanyColors {
 
 class CompanyTheme {
   static final ColorScheme companyColorSchemeLight = ColorScheme.fromSeed(
-      seedColor: CompanyColors.greenPrimary, brightness: Brightness.light);
+      seedColor: CompanyColors.greenSecondary, brightness: Brightness.light);
 
   static final ColorScheme companyColorSchemeDark = ColorScheme.fromSeed(
-      seedColor: CompanyColors.greenPrimary, brightness: Brightness.dark);
+      seedColor: CompanyColors.greenSecondary, brightness: Brightness.dark);
 }

--- a/lib/company_data.dart
+++ b/lib/company_data.dart
@@ -41,32 +41,9 @@ class CompanyColors {
 }
 
 class CompanyTheme {
-  static final greenSecondaryMatCol =
-      _createMaterialColor(CompanyColors.greenSecondary);
+  static final ColorScheme companyColorSchemeLight = ColorScheme.fromSeed(
+      seedColor: CompanyColors.greenPrimary, brightness: Brightness.light);
 
-  static final ThemeData companyLight =
-      ThemeData(colorSchemeSeed: greenSecondaryMatCol);
-
-  static final ThemeData companyDark = ThemeData(
-      brightness: Brightness.dark, colorSchemeSeed: greenSecondaryMatCol);
-
-  static MaterialColor _createMaterialColor(Color color) {
-    List strengths = <double>[.05];
-    final swatch = <int, Color>{};
-    final int r = color.red, g = color.green, b = color.blue;
-
-    for (int i = 1; i < 10; i++) {
-      strengths.add(0.1 * i);
-    }
-    for (var strength in strengths) {
-      final double ds = 0.5 - strength;
-      swatch[(strength * 1000).round()] = Color.fromRGBO(
-        r + ((ds < 0 ? r : (255 - r)) * ds).round(),
-        g + ((ds < 0 ? g : (255 - g)) * ds).round(),
-        b + ((ds < 0 ? b : (255 - b)) * ds).round(),
-        1,
-      );
-    }
-    return MaterialColor(color.value, swatch);
-  }
+  static final ColorScheme companyColorSchemeDark = ColorScheme.fromSeed(
+      seedColor: CompanyColors.greenPrimary, brightness: Brightness.dark);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'dart:io';
 
 import 'package:background_fetch/background_fetch.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -102,6 +103,8 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    redoSystemStyle(
+        MediaQuery.of(context).platformBrightness == Brightness.dark);
     return DynamicColorBuilder(
         builder: (ColorScheme? lightColorScheme, ColorScheme? darkColorScheme) {
       return MaterialApp(
@@ -114,12 +117,40 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         navigatorKey: MyApp.navigatorKey,
         title: applicationName,
         theme: ThemeData(
-            colorScheme: lightColorScheme ?? CompanyTheme.companyColorSchemeLight),
+            colorScheme:
+                lightColorScheme ?? CompanyTheme.companyColorSchemeLight),
         darkTheme: ThemeData(
-            colorScheme: darkColorScheme ?? CompanyTheme.companyColorSchemeDark),
+            colorScheme:
+                darkColorScheme ?? CompanyTheme.companyColorSchemeDark),
         home: const WalksHomeScreen(),
         debugShowCheckedModeBanner: false,
       );
     });
+  }
+
+  Future<void> redoSystemStyle(bool darkMode) async {
+    if (Platform.isAndroid) {
+      DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
+      final AndroidDeviceInfo androidInfo = await deviceInfo.androidInfo;
+      final bool edgeToEdge = androidInfo.version.sdkInt >= 29;
+
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+
+      SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent, // Not relevant to this issue
+        systemNavigationBarColor: edgeToEdge
+            ? Colors.transparent
+            : darkMode
+                ? Colors.black
+                : Colors.white,
+        systemNavigationBarContrastEnforced: true,
+        systemNavigationBarIconBrightness:
+            darkMode ? Brightness.light : Brightness.dark,
+      ));
+    } else {
+      SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
+        statusBarColor: Colors.transparent, // Not relevant to this issue
+      ));
+    }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:dynamic_color/dynamic_color.dart';
 import 'package:points_verts/constants.dart';
 import 'package:points_verts/services/assets.dart';
 import 'package:points_verts/services/background_fetch.dart';
@@ -101,19 +102,24 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      localizationsDelegates: GlobalMaterialLocalizations.delegates,
-      supportedLocales: const [
-        Locale('fr', 'BE'),
-        Locale('fr', 'FR'),
-        Locale('fr', 'LU'),
-      ],
-      navigatorKey: MyApp.navigatorKey,
-      title: applicationName,
-      theme: CompanyTheme.companyLight,
-      darkTheme: CompanyTheme.companyDark,
-      home: const WalksHomeScreen(),
-      debugShowCheckedModeBanner: false,
-    );
+    return DynamicColorBuilder(
+        builder: (ColorScheme? lightColorScheme, ColorScheme? darkColorScheme) {
+      return MaterialApp(
+        localizationsDelegates: GlobalMaterialLocalizations.delegates,
+        supportedLocales: const [
+          Locale('fr', 'BE'),
+          Locale('fr', 'FR'),
+          Locale('fr', 'LU'),
+        ],
+        navigatorKey: MyApp.navigatorKey,
+        title: applicationName,
+        theme: ThemeData(
+            colorScheme: lightColorScheme ?? CompanyTheme.companyColorSchemeLight),
+        darkTheme: ThemeData(
+            colorScheme: darkColorScheme ?? CompanyTheme.companyColorSchemeDark),
+        home: const WalksHomeScreen(),
+        debugShowCheckedModeBanner: false,
+      );
+    });
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,6 +169,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: "77f757b789ff68e4eaf9c56d1752309bd9f7ad557cb105b938a7f8eb89e59110"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.2"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   dynamic_color:
     dependency: "direct main"
     description:
@@ -1098,6 +1114,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "41fd8a189940d8696b1b810efb9abcf60827b6cbfab90b0c43e8439e3a39d85a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   wkt_parser:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  dynamic_color:
+    dependency: "direct main"
+    description:
+      name: dynamic_color
+      sha256: eae98052fa6e2826bdac3dd2e921c6ce2903be15c6b7f8b6d8a5d49b5086298d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.7.0"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   firebase_remote_config: ^4.2.4
   firebase_analytics: ^10.4.4
   dynamic_color: ^1.7.0
+  device_info_plus: ^9.1.2
 
 dev_dependencies:
   flutter_lints: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   uuid: ^4.2.0
   firebase_remote_config: ^4.2.4
   firebase_analytics: ^10.4.4
+  dynamic_color: ^1.7.0
 
 dev_dependencies:
   flutter_lints: ^3.0.0


### PR DESCRIPTION
Add support to display a theme matching the general Android system ( Material You).

TODO: settings to select between "Material You" and "Points Verts", with "Points Verts" as default